### PR TITLE
add lwlog port

### DIFF
--- a/ports/lwlog/portfile.cmake
+++ b/ports/lwlog/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ChristianPanov/lwlog
+    REF v${VERSION}
+    SHA512 e4332bdb04617ebd38efd19367290ed69d36f6ed1d9c61a907f0639b5a58feaba715f807286291a923482d935eba971afa8db000d0b70611c1f97bf541c6229e
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake)
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")

--- a/ports/lwlog/usage
+++ b/ports/lwlog/usage
@@ -1,0 +1,6 @@
+lwlog provides CMake targets: 
+
+    find_package(TinyTIFF CONFIG REQUIRED)
+
+    target_link_libraries(main PRIVATE lwlog::lwlog_lib)
+    

--- a/ports/lwlog/vcpkg.json
+++ b/ports/lwlog/vcpkg.json
@@ -1,0 +1,18 @@
+{
+    "name": "lwlog",
+    "version": "1.3.1",
+    "description": "Very fast synchronous and asynchronous C++17 logging library.",
+    "homepage": "https://github.com/ChristianPanov/lwlog",
+    "license": "MIT",
+    "dependencies": [
+      {
+        "name": "vcpkg-cmake",
+        "host": true
+      },
+      {
+        "name": "vcpkg-cmake-config",
+        "host": true
+      }
+    ]
+  }
+  

--- a/ports/lwlog/vcpkg.json
+++ b/ports/lwlog/vcpkg.json
@@ -1,18 +1,17 @@
 {
-    "name": "lwlog",
-    "version": "1.3.1",
-    "description": "Very fast synchronous and asynchronous C++17 logging library.",
-    "homepage": "https://github.com/ChristianPanov/lwlog",
-    "license": "MIT",
-    "dependencies": [
-      {
-        "name": "vcpkg-cmake",
-        "host": true
-      },
-      {
-        "name": "vcpkg-cmake-config",
-        "host": true
-      }
-    ]
-  }
-  
+  "name": "lwlog",
+  "version": "1.3.1",
+  "description": "Very fast synchronous and asynchronous C++17 logging library.",
+  "homepage": "https://github.com/ChristianPanov/lwlog",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -5712,6 +5712,10 @@
       "baseline": "1.18.10",
       "port-version": 1
     },
+    "lwlog": {
+      "baseline": "1.3.1",
+      "port-version": 0
+    },
     "lz4": {
       "baseline": "1.10.0",
       "port-version": 0

--- a/versions/l-/lwlog.json
+++ b/versions/l-/lwlog.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "61e42c1425f77abf0d1afdc5601c9b57f4f4ecdc",
+      "version": "1.3.1",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [x] SHA512s are updated for each updated download.
- [ ] The "supports" clause reflects platforms that may be fixed by this new version.
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

